### PR TITLE
Fix pointer type for 64bit arch

### DIFF
--- a/lib/yapper/document/selection.rb
+++ b/lib/yapper/document/selection.rb
@@ -80,8 +80,9 @@ module Yapper::Document
       @options  = options
     end
 
+    PointerType = (CGSize.type[/(f|d)/] == 'f') ? :uint : :ulong_long
     def count
-      count_ptr = Pointer.new(:uint)
+      count_ptr = Pointer.new(PointerType)
       @klass.db.execute { |txn| txn.ext("#{@klass._type}_IDX").getNumberOfRows(count_ptr, matchingQuery: query) }
       count_ptr.value
     end


### PR DESCRIPTION
If enable 64bit arch like below,

``` ruby
Motion::Project::App.setup do |app|
  ...
  app.archs['iPhoneSimulator'] << 'x86_64'
  app.archs['iPhoneOS'] << 'arm64'
```

then some spec fails in where use Pointer object.

```
$ be rake spec
     Build ./build/iPhoneSimulator-8.1-Development
     Build /Users/watson/tmp/yapper/vendor/YapDatabaseRubyMotion
   Compile /Users/watson/tmp/yapper/vendor/YapDatabaseRubyMotion/YapDatabaseRubyMotion.m
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: warning for library: libYapDatabaseRubyMotion.a for architecture: i386 the table of contents is empty (no object file members in the library define global symbols)
warning: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: warning for library: libYapDatabaseRubyMotion.a for architecture: x86_64 the table of contents is empty (no object file members in the library define global symbols)
   Compile /Users/watson/tmp/yapper/build/redgreen_style_config.rb
      Link ./build/iPhoneSimulator-8.1-Development/Yapper_spec.app/Yapper
    Create ./build/iPhoneSimulator-8.1-Development/Yapper_spec.app/Info.plist
    Create ./build/iPhoneSimulator-8.1-Development/Yapper_spec.app.dSYM
  Simulate ./build/iPhoneSimulator-8.1-Development/Yapper_spec.app
Bacon Output Style: :full
callbacks

creating documents
  - before and after callbacks are fired
 [✓] This test has passed! Good job!


updating documents
  - before and after callbacks are fired
 [✓] This test has passed! Good job!


on failure
  - rollsback the entire update
 [✗] This test has not passed: ERROR: TypeError - expected instance of Pointer of type `Q', got `I'!
 [ERROR: TypeError - expected instance of Pointer of type `Q', got `I']
 BACKTRACE: TypeError: expected instance of Pointer of type `Q', got `I'
    selection.rb:85:in `block in count': on failure - rollsback the entire update
    db.rb:239:in `block in run'
    db.rb:245:in `run'
    db.rb:47:in `execute:'
    selection.rb:85:in `count'
    spec.rb:316:in `block in run_spec_block'
    spec.rb:440:in `execute_block'
    spec.rb:316:in `run_spec_block'
    spec.rb:331:in `run'
```

Looks like it need different pointer type between 32bit and 64bit.
